### PR TITLE
allow credentials in GET requests

### DIFF
--- a/wsgicors.py
+++ b/wsgicors.py
@@ -82,6 +82,10 @@ class CORS(object):
                     origin = "*"
                 if origin:
                     headers.append(('Access-Control-Allow-Origin', origin))
+
+                if self.pol_credentials == 'true':
+                    headers.append(('Access-Control-Allow-Credentials', 'true'))
+
                 return start_response(status, headers, exc_info)
         else:
             custom_start_response = start_response


### PR DESCRIPTION
I think you might have thought that the only 
thing you'd have to set in a non-OPTIONS 
request was Access-Control-Allow-Origin,
but if you are trying to pass cookies, you also 
need to allow Access-Control-Allow-Credentials.

see: https://developer.mozilla.org/en-US/docs/HTTP/Access_control_CORS#Access-Control-Allow-Credentials
