### PR TITLE
refactoring for python 3.x environment

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include CHANGES.txt
-include README.txt
+include CHANGES.md
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import sys, os
 version = '0.3'
 
 here = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(here, 'README.txt')).read()
-CHANGES = open(os.path.join(here, 'CHANGES.txt')).read()
+README = open(os.path.join(here, 'README.md')).read()
+CHANGES = open(os.path.join(here, 'CHANGES.md')).read()
 
 # hack, or test wont run on py2.7
 try:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27
+envlist = py27, py33, py34
 [testenv]
 deps=
     nose

--- a/wsgicors.py
+++ b/wsgicors.py
@@ -1,36 +1,39 @@
 import fnmatch
+from functools import reduce
+
 
 class CORS(object):
     "WSGI middleware allowing CORS requests to succeed"
 
     def __init__(self, application, cfg=None, **kw):
 
-        if kw: # direct config
+        if kw:  # direct config
             self.policy = "direct"
-        else: # via configfile, paster factory for instance
+        else:  # via configfile, paster factory for instance
             cfg = cfg or {}
             self.policy = cfg.get("policy", "deny")
             kw = {}
-            prefix=self.policy+"_"
-            for k, v in filter(lambda (k, v): k.startswith(prefix), cfg.items()):
+            prefix = self.policy + "_"
+            for k, v in filter(lambda key_value: key_value[0].startswith(prefix), cfg.items()):
                 kw[k.split(prefix)[-1]] = v
 
-
-        self.pol_origin = kw.get("origin", "") # copy or * or a space separated list of hostnames, possibly with filename wildcards "*" and "?"
+        self.pol_origin = kw.get("origin",
+                                 "")  # copy or * or a space separated list of hostnames, possibly with filename wildcards "*" and "?"
         if self.pol_origin not in ("copy", "*"):
-            self.match=filter(lambda x: x != "*", map(lambda x: x.strip(), self.pol_origin.split(" ")))
+            self.match = list(filter(lambda x: x != "*", map(lambda x: x.strip(), self.pol_origin.split(" "))))
         else:
             self.match = []
-        self.pol_origin = kw.get("origin", "") # copy or * or a space separated list of hostnames, possibly with filename wildcards "*" and "?"
+        self.pol_origin = kw.get("origin",
+                                 "")  # copy or * or a space separated list of hostnames, possibly with filename wildcards "*" and "?"
 
-        self.pol_methods = kw.get("methods", "") # * or list of methods
-        self.pol_headers = kw.get("headers", "") # * or list of headers
-        self.pol_credentials = kw.get("credentials", "false") # true or false
-        self.pol_maxage = kw.get("maxage", "") # in seconds
-            
+        self.pol_methods = kw.get("methods", "")  # * or list of methods
+        self.pol_headers = kw.get("headers", "")  # * or list of headers
+        self.pol_credentials = kw.get("credentials", "false")  # true or false
+        self.pol_maxage = kw.get("maxage", "")  # in seconds
+
         self.application = application
- 
- 
+
+
     def __call__(self, environ, start_response):
 
         def matchpattern(accu, pattern, host):
@@ -48,7 +51,7 @@ class CORS(object):
                 credentials = None
                 maxage = None
 
-                orig=environ.get("HTTP_ORIGIN",None)
+                orig = environ.get("HTTP_ORIGIN", None)
                 if orig and self.match:
                     if reduce(lambda accu, x: matchpattern(accu, x, orig.lower()), self.match, False):
                         origin = orig
@@ -58,12 +61,12 @@ class CORS(object):
                     origin = self.pol_origin
 
                 if self.pol_methods == "*":
-                    methods = environ.get("HTTP_ACCESS_CONTROL_REQUEST_METHOD",None)
+                    methods = environ.get("HTTP_ACCESS_CONTROL_REQUEST_METHOD", None)
                 elif self.pol_methods:
                     methods = self.pol_methods
 
                 if self.pol_headers == "*":
-                    headers = environ.get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS",None)
+                    headers = environ.get("HTTP_ACCESS_CONTROL_REQUEST_HEADERS", None)
                 elif self.pol_headers:
                     headers = self.pol_headers
 
@@ -72,25 +75,24 @@ class CORS(object):
 
                 if self.pol_maxage:
                     maxage = self.pol_maxage
-                
+
                 if origin: resp.append(('Access-Control-Allow-Origin', origin))
                 if methods: resp.append(('Access-Control-Allow-Methods', methods))
                 if headers: resp.append(('Access-Control-Allow-Headers', headers))
                 if credentials: resp.append(('Access-Control-Allow-Credentials', credentials))
                 if maxage: resp.append(('Access-Control-Max-Age', maxage))
 
-
             status = '204 OK'
             start_response(status, resp)
             return []
 
-
-        orig=environ.get("HTTP_ORIGIN",None)
+        orig = environ.get("HTTP_ORIGIN", None)
         if orig and self.policy != "deny":
             def custom_start_response(status, headers, exc_info=None):
                 origin = None
 
-                if orig and self.match and reduce(lambda accu, x: matchpattern(accu, x, orig.lower()), self.match, False):
+                if orig and self.match and reduce(lambda accu, x: matchpattern(accu, x, orig.lower()), self.match,
+                                                  False):
                     origin = orig
                 elif self.pol_origin == "copy":
                     origin = orig
@@ -102,7 +104,7 @@ class CORS(object):
                 if self.pol_credentials == 'true' and self.pol_origin == "*":
                     # for credentialed access '*' are ignored in origin
                     origin = orig
-                    
+
                 if origin:
                     headers.append(('Access-Control-Allow-Origin', origin))
 
@@ -112,8 +114,9 @@ class CORS(object):
                 return start_response(status, headers, exc_info)
         else:
             custom_start_response = start_response
- 
+
         return self.application(environ, custom_start_response)
+
 
 def make_middleware(app, cfg=None, **kw):
     cfg = (cfg or {}).copy()


### PR DESCRIPTION
-modified references to CHANGES and README from '.txt' to '.md' (wouldn't build otherwise)

-added testing for python 3.3 and 3.4 in tox config

-refactored code so as to pass existing unit tests in python 3.3-3.4 environments. (no further test created)
