### PR TITLE
Fixed typo in MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include *.rst
 include test*.py
-LICENSE
+include LICENSE


### PR DESCRIPTION
At least pip was giving following warning on installation:

    warning: manifest_maker: MANIFEST.in, line 3: unknown action 'LICENSE'