### PR TITLE
Add support for Access-Control-Expose-Headers

### DIFF
--- a/wsgicors.py
+++ b/wsgicors.py
@@ -48,6 +48,7 @@ class CORS(object):
         self.pol_origin = kw.get("origin", "")  
         self.pol_methods = kw.get("methods", "")  # * or list of methods
         self.pol_headers = kw.get("headers", "")  # * or list of headers
+        self.pol_expose_headers = kw.get("expose_headers", "")  # * or list of headers
         self.pol_credentials = kw.get("credentials", "false")  # true or false
         self.pol_maxage = kw.get("maxage", "")  # in seconds
 
@@ -132,6 +133,9 @@ class CORS(object):
 
                     if self.pol_credentials == 'true':
                         headers.append(('Access-Control-Allow-Credentials', 'true'))
+
+                    if self.pol_expose_headers:
+                        headers.append(('Access-Control-Expose-Headers', self.pol_expose_headers))
 
                 return start_response(status, headers, exc_info)
         else:


### PR DESCRIPTION
This optional header permits the User Agent to expose the listed response headers to the requesting script.
By experiment, it goes on the response to the real request, not the preflight OPTIONS request.