### PR TITLE
Only handle OPTIONS requests ourselves if there is an Access-Control-…

### DIFF
--- a/wsgicors.py
+++ b/wsgicors.py
@@ -63,7 +63,7 @@ class CORS(object):
         def matchlist(origin, allowed_origins):
             return reduce(lambda accu, x: matchpattern(accu, x, origin.lower()), allowed_origins, False)
 
-        if 'OPTIONS' == environ['REQUEST_METHOD']:
+        if 'OPTIONS' == environ['REQUEST_METHOD'] and environ.get("HTTP_ACCESS_CONTROL_REQUEST_METHOD") is not None:
             resp = []
             if self.policy == "deny":
                 pass


### PR DESCRIPTION
…Request-Method header, in addition to method OPTIONS. This header is required in a preflight request according to http://www.w3.org/TR/cors/#preflight-request .